### PR TITLE
Solve "undefined reference to ..." linking errors: LDFLAGS after OFILES.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ $(OUTPUT): $(TARGET).elf
 
 $(TARGET).elf: $(OFILES)
 	@echo "[LD]    $(notdir $@)"
-	@$(LD) $(LDFLAGS) $(OFILES) -o $@ -Wl,-Map=$(@:.elf=.map)
+	@$(LD) $(OFILES) $(LDFLAGS) -o $@ -Wl,-Map=$(@:.elf=.map)
 
 -include $(DEPSDIR)/*.d
 


### PR DESCRIPTION
This was a problem in Pop_OS 22.04 LTS, based on Ubuntu 22.04 LTS.

The issue seems to be the order in which the linking is done at line 74 in the Makefile:
@$(LD) $(LDFLAGS) $(OFILES) -o $@ -Wl,-Map=$(@:.elf=.map)
Which expands to:
gcc -Wl,-x -Wl,--gc-sections -lglut -lm -lGL -O3 -g  main.o mtx.o shader.o main.frag.o main.vert.o -o veles.elf -Wl,-Map=veles.map

The correct order, as far as I know, is to have the libraries after the object files, like this:
gcc main.o mtx.o shader.o main.frag.o main.vert.o -Wl,-x -Wl,--gc-sections -lGL -lglut -lm -O3 -g  -o veles.elf -Wl,-Map=veles.map

Fixes #1.